### PR TITLE
Install instructions for ARM-based Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ OG-ZAF is an overlapping-generations (OG) model that allows for dynamic general 
   * From the terminal (or Anaconda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment-M1.yml`. The process of creating the `ogzaf-dev` conda environment should not take more than five minutes.
   * Then, `conda activate ogzaf-dev`
   * Then, `pip install --no-dependencies ogcore`
+  * Then install by `pip install -e .`
 * **If you are installing this on a Windows or Intel Mac:**
   * From the terminal (or Anaconda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment.yml`. The process of creating the `ogzaf-dev` conda environment should not take more than five minutes.
   * Then, `conda activate ogzaf-dev`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OG-ZAF is an overlapping-generations (OG) model that allows for dynamic general 
 * **If you are installing this on a Windows or Intel Mac:**
   * From the terminal (or Anaconda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment.yml`. The process of creating the `ogzaf-dev` conda environment should not take more than five minutes.
   * Then, `conda activate ogzaf-dev`
-* Then install by `pip install -e .`
+  * Then install by `pip install -e .`
 ### Run an example of the model
 * Navigate to `./examples`
 * Run the model with an example reform from terminal/command prompt by typing `python run_og_zaf.py`

--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ OG-ZAF is an overlapping-generations (OG) model that allows for dynamic general 
 
 ## Using and contributing to OG-ZAF
 
-* Install the [Anaconda distribution](https://www.anaconda.com/distribution/) of Python
+* If you are installing on a Mac computer, install XCode Tools. In Terminal: `xcode-select —install`
+* Download and install the appropriate [Anaconda distribution](https://www.anaconda.com/products/distribution#Downloads) of Python. Select the correct version for you platform (Windows, Intel Mac, or M1 Mac).
+* In Terminal:
   * Make sure the `conda` package manager is up-to-date: `conda update conda`.
   * Make sure the Anaconda distribution of Python is up-to-date: `conda update anaconda`.
 * Fork this repository and clone your fork of this repository to a directory on your computer.
-* From the terminal (or Anaconda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment.yml`. The process of creating the `ogzaf-dev` conda environment should not take more than five minutes.
-* Then, `conda activate ogzaf-dev`
+* **If you are installing this on a M1/M2 Mac (ARM):**
+  * From the terminal (or Anaconda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment-M1.yml`. The process of creating the `ogzaf-dev` conda environment should not take more than five minutes.
+  * Then, `conda activate ogzaf-dev`
+  * Then, `pip install --no-dependencies ogcore`
+* **If you are installing this on a Windows or Intel Mac:**
+  * From the terminal (or Anaconda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment.yml`. The process of creating the `ogzaf-dev` conda environment should not take more than five minutes.
+  * Then, `conda activate ogzaf-dev`
 * Then install by `pip install -e .`
+### Run an example of the model
 * Navigate to `./examples`
 * Run the model with an example reform from terminal/command prompt by typing `python run_og_zaf.py`
 * You can adjust the `./examples/run_og_zaf.py` by modifying model parameters specified in the dictionary passed to the `p.update_specifications()` calls.
@@ -32,7 +40,7 @@ OG-ZAF is an overlapping-generations (OG) model that allows for dynamic general 
     * See [`ogcore.TPI.py`](https://github.com/PSLmodels/OG-Core/blob/master/ogcore/TPI.py) for what is in the dictionary object in this pickle file
   * An analogous set of files in the `./examples/OUTPUT_REFORM` directory, which represent objects from the simulation of the reform policy
 
-Note that, depending on your machine, a full model run (solving for the full time path equilibrium for the baseline and reform policies) can take more than two hours of compute time.
+Note that, depending on your machine, a full model run (solving for the full time path equilibrium for the baseline and reform policies) can take from 35 minutes to more than two hours of compute time.
 
 If you run into errors running the example script, please open a new issue in the OG-ZAF repo with a description of the issue and any relevant tracebacks you receive.
 

--- a/environment-M1.yml
+++ b/environment-M1.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python>=3.7.7, <=3.9.12  # This restriction can be removed as soon as these packages support Python 3.10
-- mkl>=2020.2  
+#- mkl>=2020.2  ## this fails on M1 Mac: "ResolvePackageNotFound:  - mkl[version='>=2020.2']"
 - numpy<=1.21.2  # This restriction can be removed as soon as Numba supports NumPy 1.22
 - psutil
 - scipy>=1.5.0
@@ -31,4 +31,4 @@ dependencies:
 - pip:
   - jupyter-book>=0.9.1
   - pandas-datareader
-  - ogcore
+  #- ogcore

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
-name: ogzaf-dev
+name: ogzaf-test
 channels:
 - conda-forge
 dependencies:
 - python>=3.7.7, <=3.9.12  # This restriction can be removed as soon as these packages support Python 3.10
-- mkl>=2020.2
+#- mkl>=2020.2  ## this fails on M1 Mac: "ResolvePackageNotFound:  - mkl[version='>=2020.2']"
 - numpy<=1.21.2  # This restriction can be removed as soon as Numba supports NumPy 1.22
 - psutil
 - scipy>=1.5.0
@@ -31,4 +31,4 @@ dependencies:
 - pip:
   - jupyter-book>=0.9.1
   - pandas-datareader
-  - ogcore
+  #- ogcore


### PR DESCRIPTION
This PR:

- It points to the proper distribution of Anaconda (ARM), which also installs the correct distribution of Python (ARM). 
- Creates a `environment-M1.yml` file that has the correct dependencies needed for installing on ARM Macs, [as described in this comment](https://github.com/EAPD-DRB/OG-ZAF/issues/3#issue-1410280233). 
- Updates the Read Me with instructions specific for those installing on ARM-based Macs: 1) don't install the `mkl` dependency, and 2) install the `ogcore` dependency as a separate step. 

This solves #15 