### PR TITLE
Removed openssl from setup.py list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setuptools.setup(
     python_requires=">=3.7.7, <3.11",
     install_requires=[
         "psutil",
-        "openssl=1.1.1",
         "numpy<=1.21.2",
         "scipy>=1.7.1",
         "pandas>=1.2.5",


### PR DESCRIPTION
This PR removes the `openssl==1.1.1` requirement (which was misentered as `openssl=1.1.1`). For some reason, the `ogzaf` package cannot be installed with this setting in `setup.py`. See Issue #26 for details. For now, we will just remove it from `setup.py`.

cc: @SeaCelo 