### PR TITLE
Added three example run scripts for UN

### DIFF
--- a/examples/UN_examples/run_og_zaf_multiple_industry_cit_cut.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_cit_cut.py
@@ -1,0 +1,145 @@
+# Need to fix references to Calculator, reform json, and substitute new tax
+# function call
+import multiprocessing
+from distributed import Client
+import os
+import json
+import time
+import copy
+import numpy as np
+
+# from taxcalc import Calculator
+from ogzaf.calibrate import Calibration
+from ogcore.parameters import Specifications
+from ogcore import output_tables as ot
+from ogcore import output_plots as op
+from ogcore.execute import runner
+from ogcore.utils import safe_read_pickle
+
+
+def main():
+    # Define parameters to use for multiprocessing
+    client = Client()
+    num_workers = min(multiprocessing.cpu_count(), 7)
+    print("Number of workers = ", num_workers)
+
+    # Directories to save data
+    CUR_DIR = os.path.dirname(os.path.realpath(__file__))
+    base_dir = os.path.join(CUR_DIR, "OG-ZAF-CIT_Example", "OUTPUT_BASELINE")
+    reform_dir = os.path.join(CUR_DIR, "OG-ZAF-CIT_Example", "OUTPUT_REFORM")
+
+    """
+    ---------------------------------------------------------------------------
+    Run baseline policy
+    ---------------------------------------------------------------------------
+    """
+    # Set up baseline parameterization
+    p = Specifications(
+        baseline=True,
+        num_workers=num_workers,
+        baseline_dir=base_dir,
+        output_base=base_dir,
+    )
+    # Update parameters for baseline from default json file
+    p.update_specifications(
+        json.load(
+            open(
+                os.path.join(
+                    CUR_DIR, "..", "..", "ogzaf",
+                    "ogzaf_default_parameters.json"
+                )
+            )
+        )
+    )
+    # Update parameters from calibrate.py Calibration class
+    p.M = 4
+    p.I = 5
+    c = Calibration(p)
+    updated_params = c.get_dict()
+    p.update_specifications(updated_params)
+    updated_params_tax = {
+        "etr_params": [[[0.35]]],
+        "mtrx_params": [[[0.35]]],
+        "mtry_params": [[[0.35]]],
+        "cit_rate": [[0.28, 0.28, 0.28, 0.28]],
+        # order of industries is primary, energy, tertiary, secondary ex energy
+        "Z": [[0.5, 0.4, 1.7, 1.0]],
+        # Rick had good suggestion of using last successful run to find starting values and then keep churning.
+        "epsilon": [1.0, 1.0, 1.0, 1.0],
+        "gamma": [0.67, 0.50, 0.45, 0.53],
+        "gamma_g": [0.0, 0.0, 0.0, 0.0],
+        "alpha_c": c.alpha_c,
+        "io_matrix": c.io_matrix,
+        "tG1": 23,
+        "debt_ratio_ss": 2.0,
+    }
+    p.update_specifications(updated_params_tax)
+
+    # Run model
+    start_time = time.time()
+    runner(p, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+
+    """
+    ---------------------------------------------------------------------------
+    Run reform policy
+    ---------------------------------------------------------------------------
+    """
+
+    # create new Specifications object for reform simulation
+    p2 = copy.deepcopy(p)
+    p2.baseline = False
+    p2.output_base = reform_dir
+
+    # additional parameters to change
+    updated_params_ref = {
+        "cit_rate": [[0.25, 0.25, 0.25, 0.25]],
+        "baseline_spending": True,
+    }
+    p2.update_specifications(updated_params_ref)
+
+    # Run model
+    start_time = time.time()
+    runner(p2, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+    client.close()
+
+    """
+    ---------------------------------------------------------------------------
+    Save some results of simulations
+    ---------------------------------------------------------------------------
+    """
+    base_tpi = safe_read_pickle(os.path.join(base_dir, "TPI", "TPI_vars.pkl"))
+    base_params = safe_read_pickle(os.path.join(base_dir, "model_params.pkl"))
+    reform_tpi = safe_read_pickle(
+        os.path.join(reform_dir, "TPI", "TPI_vars.pkl")
+    )
+    reform_params = safe_read_pickle(
+        os.path.join(reform_dir, "model_params.pkl")
+    )
+    ans = ot.macro_table(
+        base_tpi,
+        base_params,
+        reform_tpi=reform_tpi,
+        reform_params=reform_params,
+        var_list=["Y", "C", "K", "L", "r", "w"],
+        output_type="pct_diff",
+        num_years=10,
+        start_year=base_params.start_year,
+    )
+
+    # create plots of output
+    op.plot_all(
+        base_dir,
+        reform_dir,
+        os.path.join(CUR_DIR, "OG-ZAF_CIT_multi_industry_plots"),
+    )
+
+    print("Percentage changes in aggregates:", ans)
+    # save percentage change output to csv file
+    ans.to_csv("ogzaf_CIT_multi_industry_output.csv")
+
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()

--- a/examples/UN_examples/run_og_zaf_multiple_industry_cit_cut.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_cit_cut.py
@@ -45,8 +45,11 @@ def main():
         json.load(
             open(
                 os.path.join(
-                    CUR_DIR, "..", "..", "ogzaf",
-                    "ogzaf_default_parameters.json"
+                    CUR_DIR,
+                    "..",
+                    "..",
+                    "ogzaf",
+                    "ogzaf_default_parameters.json",
                 )
             )
         )

--- a/examples/UN_examples/run_og_zaf_multiple_industry_govt_borrow_shock.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_govt_borrow_shock.py
@@ -49,8 +49,11 @@ def main():
         json.load(
             open(
                 os.path.join(
-                    CUR_DIR, "..", "..", "ogzaf",
-                    "ogzaf_default_parameters.json"
+                    CUR_DIR,
+                    "..",
+                    "..",
+                    "ogzaf",
+                    "ogzaf_default_parameters.json",
                 )
             )
         )

--- a/examples/UN_examples/run_og_zaf_multiple_industry_govt_borrow_shock.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_govt_borrow_shock.py
@@ -1,0 +1,153 @@
+# Need to fix references to Calculator, reform json, and substitute new tax
+# function call
+import multiprocessing
+from distributed import Client
+import os
+import json
+import time
+import copy
+import numpy as np
+
+# from taxcalc import Calculator
+from ogzaf.calibrate import Calibration
+from ogcore.parameters import Specifications
+from ogcore import output_tables as ot
+from ogcore import output_plots as op
+from ogcore.execute import runner
+from ogcore.utils import safe_read_pickle
+
+
+def main():
+    # Define parameters to use for multiprocessing
+    client = Client()
+    num_workers = min(multiprocessing.cpu_count(), 7)
+    print("Number of workers = ", num_workers)
+
+    # Directories to save data
+    CUR_DIR = os.path.dirname(os.path.realpath(__file__))
+    base_dir = os.path.join(
+        CUR_DIR, "OG-ZAF-govt_borrow_shock_Example", "OUTPUT_BASELINE"
+    )
+    reform_dir = os.path.join(
+        CUR_DIR, "OG-ZAF-govt_borrow_shock_Example", "OUTPUT_REFORM"
+    )
+
+    """
+    ---------------------------------------------------------------------------
+    Run baseline policy
+    ---------------------------------------------------------------------------
+    """
+    # Set up baseline parameterization
+    p = Specifications(
+        baseline=True,
+        num_workers=num_workers,
+        baseline_dir=base_dir,
+        output_base=base_dir,
+    )
+    # Update parameters for baseline from default json file
+    p.update_specifications(
+        json.load(
+            open(
+                os.path.join(
+                    CUR_DIR, "..", "..", "ogzaf",
+                    "ogzaf_default_parameters.json"
+                )
+            )
+        )
+    )
+    # Update parameters from calibrate.py Calibration class
+    p.M = 4
+    p.I = 5
+    c = Calibration(p)
+    updated_params = c.get_dict()
+    p.update_specifications(updated_params)
+    updated_params_tax = {
+        "etr_params": [[[0.35]]],
+        "mtrx_params": [[[0.35]]],
+        "mtry_params": [[[0.35]]],
+        "cit_rate": [[0.28, 0.28, 0.28, 0.28]],
+        # order of industries is primary, energy, tertiary, secondary ex energy
+        "Z": [[0.5, 0.4, 1.7, 1.0]],
+        # Rick had good suggestion of using last successful run to find starting values and then keep churning.
+        "epsilon": [1.0, 1.0, 1.0, 1.0],
+        "gamma": [0.67, 0.50, 0.45, 0.53],
+        "gamma_g": [0.0, 0.0, 0.0, 0.0],
+        "alpha_c": c.alpha_c,
+        "io_matrix": c.io_matrix,
+        "tG1": 23,
+        "debt_ratio_ss": 2.0,
+    }
+    p.update_specifications(updated_params_tax)
+
+    # Run model
+    start_time = time.time()
+    runner(p, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+
+    """
+    ---------------------------------------------------------------------------
+    Run reform policy
+    ---------------------------------------------------------------------------
+    """
+
+    # create new Specifications object for reform simulation
+    p2 = copy.deepcopy(p)
+    p2.baseline = False
+    p2.output_base = reform_dir
+
+    # additional parameters to change
+    updated_params_ref = {
+        "r_gov_shift": [
+            -0.0337662504 - 0.02,
+            -0.0337662504 - 0.02,
+            -0.0337662504,
+        ],
+        "baseline_spending": True,
+    }
+    p2.update_specifications(updated_params_ref)
+
+    # Run model
+    start_time = time.time()
+    runner(p2, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+    client.close()
+
+    """
+    ---------------------------------------------------------------------------
+    Save some results of simulations
+    ---------------------------------------------------------------------------
+    """
+    base_tpi = safe_read_pickle(os.path.join(base_dir, "TPI", "TPI_vars.pkl"))
+    base_params = safe_read_pickle(os.path.join(base_dir, "model_params.pkl"))
+    reform_tpi = safe_read_pickle(
+        os.path.join(reform_dir, "TPI", "TPI_vars.pkl")
+    )
+    reform_params = safe_read_pickle(
+        os.path.join(reform_dir, "model_params.pkl")
+    )
+    ans = ot.macro_table(
+        base_tpi,
+        base_params,
+        reform_tpi=reform_tpi,
+        reform_params=reform_params,
+        var_list=["Y", "C", "K", "L", "r", "w"],
+        output_type="pct_diff",
+        num_years=10,
+        start_year=base_params.start_year,
+    )
+
+    # create plots of output
+    op.plot_all(
+        base_dir,
+        reform_dir,
+        os.path.join(CUR_DIR, "OG-ZAF_govt_borrow_shock_multi_industry_plots"),
+    )
+
+    print("Percentage changes in aggregates:", ans)
+    # save percentage change output to csv file
+    ans.to_csv("ogzaf_govt_borrow_shock_multi_industry_output.csv")
+
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()

--- a/examples/UN_examples/run_og_zaf_multiple_industry_overall_z_shock.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_overall_z_shock.py
@@ -49,8 +49,11 @@ def main():
         json.load(
             open(
                 os.path.join(
-                    CUR_DIR, "..", "..", "ogzaf",
-                    "ogzaf_default_parameters.json"
+                    CUR_DIR,
+                    "..",
+                    "..",
+                    "ogzaf",
+                    "ogzaf_default_parameters.json",
                 )
             )
         )

--- a/examples/UN_examples/run_og_zaf_multiple_industry_overall_z_shock.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_overall_z_shock.py
@@ -1,0 +1,154 @@
+# Need to fix references to Calculator, reform json, and substitute new tax
+# function call
+import multiprocessing
+from distributed import Client
+import os
+import json
+import time
+import copy
+import numpy as np
+
+# from taxcalc import Calculator
+from ogzaf.calibrate import Calibration
+from ogcore.parameters import Specifications
+from ogcore import output_tables as ot
+from ogcore import output_plots as op
+from ogcore.execute import runner
+from ogcore.utils import safe_read_pickle
+
+
+def main():
+    # Define parameters to use for multiprocessing
+    client = Client()
+    num_workers = min(multiprocessing.cpu_count(), 7)
+    print("Number of workers = ", num_workers)
+
+    # Directories to save data
+    CUR_DIR = os.path.dirname(os.path.realpath(__file__))
+    base_dir = os.path.join(
+        CUR_DIR, "OG-ZAF-overall_z_shock_Example", "OUTPUT_BASELINE"
+    )
+    reform_dir = os.path.join(
+        CUR_DIR, "OG-ZAF-overall_z_shock_Example", "OUTPUT_REFORM"
+    )
+
+    """
+    ---------------------------------------------------------------------------
+    Run baseline policy
+    ---------------------------------------------------------------------------
+    """
+    # Set up baseline parameterization
+    p = Specifications(
+        baseline=True,
+        num_workers=num_workers,
+        baseline_dir=base_dir,
+        output_base=base_dir,
+    )
+    # Update parameters for baseline from default json file
+    p.update_specifications(
+        json.load(
+            open(
+                os.path.join(
+                    CUR_DIR, "..", "..", "ogzaf",
+                    "ogzaf_default_parameters.json"
+                )
+            )
+        )
+    )
+    # Update parameters from calibrate.py Calibration class
+    p.M = 4
+    p.I = 5
+    c = Calibration(p)
+    updated_params = c.get_dict()
+    p.update_specifications(updated_params)
+    updated_params_tax = {
+        "etr_params": [[[0.35]]],
+        "mtrx_params": [[[0.35]]],
+        "mtry_params": [[[0.35]]],
+        "cit_rate": [[0.28, 0.28, 0.28, 0.28]],
+        # order of industries is primary, energy, tertiary, secondary ex energy
+        "Z": [[0.5, 0.4, 1.7, 1.0]],
+        # Rick had good suggestion of using last successful run to find starting values and then keep churning.
+        "epsilon": [1.0, 1.0, 1.0, 1.0],
+        "gamma": [0.67, 0.50, 0.45, 0.53],
+        "gamma_g": [0.0, 0.0, 0.0, 0.0],
+        "alpha_c": c.alpha_c,
+        "io_matrix": c.io_matrix,
+        "tG1": 23,
+        "debt_ratio_ss": 2.0,
+    }
+    p.update_specifications(updated_params_tax)
+
+    # Run model
+    start_time = time.time()
+    runner(p, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+
+    """
+    ---------------------------------------------------------------------------
+    Run reform policy
+    ---------------------------------------------------------------------------
+    """
+
+    # create new Specifications object for reform simulation
+    p2 = copy.deepcopy(p)
+    p2.baseline = False
+    p2.output_base = reform_dir
+
+    # additional parameters to change
+    updated_params_ref = {
+        "Z": [
+            [0.5 * 0.95, 0.4 * 0.95, 1.7 * 0.95, 1.0 * 0.95],
+            [0.5 * 0.975, 0.4 * 0.975, 1.7 * 0.975, 1.0 * 0.975],
+            [0.5 * 0.99, 0.4 * 0.99, 1.7 * 0.99, 1.0 * 0.99],
+            [0.5, 0.4, 1.7, 1.0],
+        ],
+        "baseline_spending": True,
+    }
+    p2.update_specifications(updated_params_ref)
+
+    # Run model
+    start_time = time.time()
+    runner(p2, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+    client.close()
+
+    """
+    ---------------------------------------------------------------------------
+    Save some results of simulations
+    ---------------------------------------------------------------------------
+    """
+    base_tpi = safe_read_pickle(os.path.join(base_dir, "TPI", "TPI_vars.pkl"))
+    base_params = safe_read_pickle(os.path.join(base_dir, "model_params.pkl"))
+    reform_tpi = safe_read_pickle(
+        os.path.join(reform_dir, "TPI", "TPI_vars.pkl")
+    )
+    reform_params = safe_read_pickle(
+        os.path.join(reform_dir, "model_params.pkl")
+    )
+    ans = ot.macro_table(
+        base_tpi,
+        base_params,
+        reform_tpi=reform_tpi,
+        reform_params=reform_params,
+        var_list=["Y", "C", "K", "L", "r", "w"],
+        output_type="pct_diff",
+        num_years=10,
+        start_year=base_params.start_year,
+    )
+
+    # create plots of output
+    op.plot_all(
+        base_dir,
+        reform_dir,
+        os.path.join(CUR_DIR, "OG-ZAF_overall_z_shock_multi_industry_plots"),
+    )
+
+    print("Percentage changes in aggregates:", ans)
+    # save percentage change output to csv file
+    ans.to_csv("ogzaf_overall_z_shock_multi_industry_output.csv")
+
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()


### PR DESCRIPTION
This PR adds the three run scripts we are demonstrating at a UN presentation. This are all in the `./examples/UN_examples/` directory.
* `run_og_zaf_multiple_industry_cit_cut.py`: a permanent 3-percentage-point cut in the corporate income tax rate across all industries from 28% to 25%.
* `run_og_zaf_multiple_industry_govt_borrow_shock.py`: A temporary (two-year) 2-percentage point increase in the government borrowing rate.
* `run_og_zaf_multiple_industry_overall_z_shock.py`: A temporary (phases out over three years) 5% TFP shock across industries.

These scripts start in 2023, and the closure rule kicks in after 23 periods (in 2046).

cc: @jdebacker, @SeaCelo, @sarvonz 