### PR TITLE
UN data portal ssl fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - ipython
 - setuptools
 - psutil
-- openssl=1.1.1  # This is a requirement of the UN data portal which we are using in demographics.py
 - numpy<=1.21.2  # This restriction can be removed as soon as Numba supports NumPy 1.22
 - scipy>=1.7.1
 - pandas>=1.2.5

--- a/ogzaf/demographics.py
+++ b/ogzaf/demographics.py
@@ -27,8 +27,7 @@ import scipy.optimize as opt
 from ogcore import parameter_plots as pp
 from pandas_datareader import wb
 import matplotlib.pyplot as plt
-import requests
-from ogzaf import utils
+from ogzaf.utils import get_legacy_session
 from io import StringIO
 
 # create output director for figures

--- a/ogzaf/demographics.py
+++ b/ogzaf/demographics.py
@@ -28,8 +28,7 @@ from ogcore import parameter_plots as pp
 from pandas_datareader import wb
 import matplotlib.pyplot as plt
 import requests
-import urllib3
-import ssl
+from ogzaf import utils
 from io import StringIO
 
 # create output director for figures
@@ -38,41 +37,6 @@ DATA_DIR = os.path.join(CUR_PATH, "data", "demographic")
 OUTPUT_DIR = os.path.join(CUR_PATH, "OUTPUT", "Demographics")
 if os.access(OUTPUT_DIR, os.F_OK) is False:
     os.makedirs(OUTPUT_DIR)
-
-"""
-------------------------------------------------------------------------
-Define functions
-------------------------------------------------------------------------
-"""
-
-"""
-The UN Data Portal server doesn't support "RFC 5746 secure renegotiation". This causes and error when the client is using OpenSSL 3, which enforces that standard by default.
-The fix is to create a custom SSL context that allows for legacy connections. This defines a function get_legacy_session() that should be used instead of requests().
-"""
-
-
-class CustomHttpAdapter(requests.adapters.HTTPAdapter):
-    # "Transport adapter" that allows us to use custom ssl_context.
-
-    def __init__(self, ssl_context=None, **kwargs):
-        self.ssl_context = ssl_context
-        super().__init__(**kwargs)
-
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = urllib3.poolmanager.PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            ssl_context=self.ssl_context,
-        )
-
-
-def get_legacy_session():
-    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT  #in Python 3.12 you will be able to switch from 0x4 to ssl.OP_LEGACY_SERVER_CONNECT.
-    session = requests.session()
-    session.mount("https://", CustomHttpAdapter(ctx))
-    return session
 
 
 def get_un_fert_data(

--- a/ogzaf/macro_params.py
+++ b/ogzaf/macro_params.py
@@ -11,6 +11,8 @@ import pandas as pd
 import numpy as np
 import datetime
 import statsmodels.api as sm
+from ogzaf import utils
+from io import StringIO
 
 
 def get_macro_params():
@@ -96,7 +98,16 @@ def get_macro_params():
         + "&format=csv"
     )
 
-    df_temp = pd.read_csv(target)
+    response = get_legacy_session().get(target)
+
+    # Check if the request was successful before processing
+    if response.status_code == 200:
+        csv_content = StringIO(response.text)
+        df_temp = pd.read_csv(csv_content)
+    else:
+        print(
+            f"Failed to retrieve data. HTTP status code: {response.status_code}"
+        )
 
     un_data_a = df_temp[["TIME_PERIOD", "OBS_VALUE"]]
 

--- a/ogzaf/macro_params.py
+++ b/ogzaf/macro_params.py
@@ -11,7 +11,7 @@ import pandas as pd
 import numpy as np
 import datetime
 import statsmodels.api as sm
-from ogzaf import utils
+from ogzaf.utils import get_legacy_session
 from io import StringIO
 
 

--- a/ogzaf/utils.py
+++ b/ogzaf/utils.py
@@ -1,0 +1,31 @@
+import requests
+import urllib3
+import ssl
+
+
+class CustomHttpAdapter(requests.adapters.HTTPAdapter):
+    """
+    The UN Data Portal server doesn't support "RFC 5746 secure renegotiation". This causes and error when the client is using OpenSSL 3, which enforces that standard by default.
+    The fix is to create a custom SSL context that allows for legacy connections. This defines a function get_legacy_session() that should be used instead of requests().
+    """
+
+    # "Transport adapter" that allows us to use custom ssl_context.
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
+
+
+def get_legacy_session():
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT  #in Python 3.12 you will be able to switch from 0x4 to ssl.OP_LEGACY_SERVER_CONNECT.
+    session = requests.session()
+    session.mount("https://", CustomHttpAdapter(ctx))
+    return session


### PR DESCRIPTION
This PR fixes https://github.com/EAPD-DRB/OG-ZAF/issues/41. 

The UN Data Portal server [doesn't support "RFC 5746 secure renegotiation"](https://www.ssllabs.com/ssltest/analyze.html?d=population.un.org). This causes an error when the client is using OpenSSL 3, which enforces that standard by default. The fix is to create a custom SSL context that allows for legacy connections. The solution follows [this diagnosis](https://github.com/urllib3/urllib3/issues/2653#issuecomment-1165307051) and [this Stackoverflow thread](https://stackoverflow.com/a/71646353).

In `demographics.py`:
- defines a function `get_legacy_session()` that should be used instead of `requests()`.
- Adjusts the `read_csv()` calls to read the output of the `get_legacy_session()` call.
- Adds some error handling

In `environment.yml`:

- Remove the need for `openssl=1.1.1`

@rickecon @jdebacker 