### PR TITLE
Update dependencies to include Python 3.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,11 @@ name: ogzaf-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7, <=3.11  # This restriction can be removed as soon as these packages support Python 3.10
+- python>=3.7.7
 - ipython
 - setuptools
 - psutil
-- numpy<=1.21.2  # This restriction can be removed as soon as Numba supports NumPy 1.22
+- numpy
 - scipy>=1.7.1
 - pandas>=1.2.5
 - matplotlib
@@ -25,7 +25,7 @@ dependencies:
 - coverage
 - requests
 - xlwt
-- openpyxl=3.1.0
+- openpyxl>=3.1.2
 - statsmodels
 - linearmodels
 - black

--- a/ogzaf/macro_params.py
+++ b/ogzaf/macro_params.py
@@ -88,7 +88,7 @@ def get_macro_params():
     """
 
     target = (
-        "https://data.un.org/ws/rest/data/IAEG-SDGs,DF_SDG_GLH,1.10/"
+        "https://data.un.org/ws/rest/data/IAEG-SDGs,DF_SDG_GLH/"
         + "..SL_EMP_GTOTL.710..........."
         + "?startPeriod="
         + str(start.year)

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,10 @@ setuptools.setup(
         ]
     },
     include_packages=True,
-    python_requires=">=3.7.7, <3.11",
+    python_requires=">=3.7.7",
     install_requires=[
         "psutil",
-        "numpy<=1.21.2",
+        "numpy",
         "scipy>=1.7.1",
         "pandas>=1.2.5",
         "matplotlib",


### PR DESCRIPTION
This PR updates the OG-ZAF  dependencies to include Python 3.11 and more recent versions of NumPy and OpenPyXL.