### PR TITLE
Update variable name for compatibility with OG-Core 0.11.13

### DIFF
--- a/ogzaf/ogzaf_default_parameters.json
+++ b/ogzaf/ogzaf_default_parameters.json
@@ -2393,7 +2393,7 @@
     "retirement_age": [
         65
     ],
-    "AIME_num_years": 35,
+    "avg_earn_num_years": 35,
     "AIME_bkt_1": 749.0,
     "AIME_bkt_2": 4517.0,
     "PIA_rate_bkt_1": 0.0,


### PR DESCRIPTION
This PR changes the name of the variable `AIME_num_years` to `avg_earn_num_years`, as was introduced in OG-Core version 0.11.13.

Resolves Issue #59 