### PR TITLE
Updated mean income in ogzaf_default_parameters.json

### DIFF
--- a/ogzaf/ogzaf_default_parameters.json
+++ b/ogzaf/ogzaf_default_parameters.json
@@ -101437,7 +101437,7 @@
             ]
         ]
     ],
-    "mean_income_data": 6766.0,
+    "mean_income_data": 123809.11,
     "frac_tax_payroll": [
         0.0,
         0.0,


### PR DESCRIPTION
This PR updates the `mean_income_data` value to 123809.11 in `ogzaf_default_parameters.json`. This value is in South African Rand and is equal to GDP per capita in 2022.

cc: @jdebacker 