### PR TITLE
Update Python version, local currency units

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Miniconda using Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           auto-update-conda: true
           activate-environment: ogzaf-dev
           environment-file: environment.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2024-12-07 12:00:00
+
+### Added
+
+- Tests on Python 3.12
+- Updates symbol for local currency units in `constants.py`
+
+
 ## [0.0.3] - 2024-07-26 12:00:00
 
 ### Added
@@ -41,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This version is a pre-release alpha. The example run script OG-ZAF/examples/run_og_zaf.py runs, but the model is not currently calibrated to represent the South African economy and population.
 
 
-
+[0.0.4]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.0...v0.0.1

--- a/docs/book/content/contributing/contributor_guide.md
+++ b/docs/book/content/contributing/contributor_guide.md
@@ -163,6 +163,6 @@ situations, in which case other contributors are here to help.
 (Sec_ContribFootnotes)=
 ## Footnotes
 
-[^recent_python]:The most recent version of Python from Anaconda is Python 3.12. `OG-ZAF` is currently tested to run on Python 3.10 and 3.11.
+[^recent_python]:The most recent version of Python from Anaconda is Python 3.12. `OG-ZAF` is currently tested to run on Python 3.11 and 3.12.
 
 [^commandline_note]:The dollar sign is the end of the command prompt on a Mac. If you are using the Windows operating system, this is usually the right angle bracket (>). No matter the symbol, you don't need to type it (or anything to its left, which shows the current working directory) at the command line before you enter a command; the prompt symbol and preceding characters should already be there.

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ogzaf-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7, <3.12
+- python>=3.7.7, <3.13
 - numpy
 - setuptools
 - wheel

--- a/ogzaf/__init__.py
+++ b/ogzaf/__init__.py
@@ -8,4 +8,4 @@ from ogzaf.input_output import *
 from ogzaf.macro_params import *
 from ogzaf.utils import *
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/ogzaf/constants.py
+++ b/ogzaf/constants.py
@@ -127,20 +127,20 @@ GROUP_LABELS = {
 }
 
 CBO_UNITS = {
-    "Y": r"Billions of ₹",
+    "Y": r"Billions of R",
     "r": "Percent",
     "w_growth": "Percent",
     "L_growth": "Percent",
-    "I_total": r"Billions of ₹",
+    "I_total": r"Billions of R",
     "L": "2012=100",
-    "C": r"Billions of ₹",
-    "agg_pension_outlays": r"Billions of ₹",
-    "G": r"Billions of ₹",
-    "iit_revenue": r"Billions of ₹",
-    "payroll_tax_revenue": r"Billions of ₹",
-    "business_tax_revenue": r"Billions of ₹",
-    "wL": r"Billions of ₹",
-    "D": r"Billions of ₹",
+    "C": r"Billions of R",
+    "agg_pension_outlays": r"Billions of R",
+    "G": r"Billions of R",
+    "iit_revenue": r"Billions of R",
+    "payroll_tax_revenue": r"Billions of R",
+    "business_tax_revenue": r"Billions of R",
+    "wL": r"Billions of R",
+    "D": r"Billions of R",
 }
 
 PARAM_LABELS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79
-target-version = ["py310", "py311"]
+target-version = ["py311", "py312"]
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     packages=["ogzaf"],
     package_data={"ogzaf": ["ogzaf_default_parameters.json", "data/*"]},
     include_packages=True,
-    python_requires=">=3.7.7, <3.12",
+    python_requires=">=3.7.7, <3.13",
     install_requires=[
         "numpy",
         "psutil",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogzaf",
-    version="0.0.3",
+    version="0.0.4",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="South Africa Calibration for OG-Core",


### PR DESCRIPTION
This PR updates OG-ZAF so that it is tested on Python 3.12.  The symbol for the local currency units in `constants.py` is also updated.