### PR TITLE
Set end date for macro data to prior calendar year

### DIFF
--- a/ogzaf/calibrate.py
+++ b/ogzaf/calibrate.py
@@ -13,7 +13,7 @@ class Calibration:
         self,
         p,
         macro_data_start_year=datetime.datetime(1947, 1, 1),
-        macro_data_end_year=datetime.date.today(),
+        macro_data_end_year=datetime.datetime(2024, 12, 31),
         demographic_data_path=None,
         output_path=None,
     ):

--- a/ogzaf/macro_params.py
+++ b/ogzaf/macro_params.py
@@ -16,7 +16,7 @@ from io import StringIO
 
 def get_macro_params(
     data_start_date=datetime.datetime(1947, 1, 1),
-    data_end_date=datetime.date.today(),
+    data_end_date=datetime.datetime(2024, 12, 31),
     country_iso="ZAF",
 ):
     """


### PR DESCRIPTION
This PR addresses Issue #77 by setting the default end date for macro data to the prior year. 
 When setting this value to "today", the year may conflict with the latest year macro data are available, leading to an input error.
