### PR TITLE
Fix typo

### DIFF
--- a/examples/run_og_zaf.py
+++ b/examples/run_og_zaf.py
@@ -1,5 +1,4 @@
-# Need to fix references to Calculator, reform json, and substitute new tax
-# function call
+# imports
 import multiprocessing
 from distributed import Client
 import os


### PR DESCRIPTION
This PR removes an unnecessary notes from the `run_og_zaf.py` script.