### PR TITLE
Prepare release 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.7] - 2025-03-12 4:00:00
+
+### Added
+
+- Updated calibration of the `io_matrix` to use the [2019 SAM file from UNU Wider](https://www.wider.unu.edu/sites/default/files/Publications/Technical-note/PDF/tn2023-1-2019-SAM-South-Africa-occupational-capital-stock-detail.pdf)
+- Updated values for `alpha_T` and `alpha_G`
+- Various updates to documentation and unit tests.
+
 ## [0.0.6] - 2025-03-03 1:00:00
 
 ### Added
@@ -67,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This version is a pre-release alpha. The example run script OG-ZAF/examples/run_og_zaf.py runs, but the model is not currently calibrated to represent the South African economy and population.
 
 
+[0.0.7]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.3...v0.0.4

--- a/ogzaf/__init__.py
+++ b/ogzaf/__init__.py
@@ -8,4 +8,4 @@ from ogzaf.input_output import *
 from ogzaf.macro_params import *
 from ogzaf.utils import *
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/ogzaf/input_output.py
+++ b/ogzaf/input_output.py
@@ -18,7 +18,7 @@ def read_SAM():
         try:
             SAM = pd.read_excel(
                 SAM_path,
-                sheet_name="SASAM 2019 61Ind 4Educ", # Can alternatively use sheet_name="SASM 2019 61Ind4Occ"
+                sheet_name="SASAM 2019 61Ind 4Educ",  # Can alternatively use sheet_name="SASM 2019 61Ind4Occ"
                 skiprows=3,
                 index_col=0,
                 storage_options=storage_options,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogzaf",
-    version="0.0.6",
+    version="0.0.7",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="South Africa Calibration for OG-Core",


### PR DESCRIPTION
This PR updates the formatting of `input_output.py` and prepares OG-ZAF for the release of version 0.0.7.