### PR TITLE
Update marsh package pin in environment.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.8] - 2025-04-28 12:00:00
+
+### Added
+
+- Updates `environment.yml` and `setup.py` to pin to version `marshmallow<4.0.0`
+
 ## [0.0.7] - 2025-03-12 4:00:00
 
 ### Added
@@ -75,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This version is a pre-release alpha. The example run script OG-ZAF/examples/run_og_zaf.py runs, but the model is not currently calibrated to represent the South African economy and population.
 
 
+[0.0.8]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/EAPD-DRB/OG-ZAF/compare/v0.0.4...v0.0.5

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - dask>=2.30.0
 - dask-core>=2.30.0
 - distributed>=2.30.1
+- marshmallow<4.0.0
 - paramtools>=0.15.0
 - sphinx>=3.5.4
 - sphinx-book-theme>=0.1.3

--- a/ogzaf/__init__.py
+++ b/ogzaf/__init__.py
@@ -8,4 +8,4 @@ from ogzaf.input_output import *
 from ogzaf.macro_params import *
 from ogzaf.utils import *
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogzaf",
-    version="0.0.7",
+    version="0.0.8",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="South Africa Calibration for OG-Core",
@@ -35,6 +35,7 @@ setuptools.setup(
         "matplotlib",
         "dask>=2.30.0",
         "distributed>=2.30.1",
+        "marshmallow<4.0.0",
         "paramtools>=0.15.0",
         "requests",
         "pandas-datareader",


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR:
- Updates `environment.yml` and `setup.py` to pin to version `marshmallow<4.0.0`. This is a temporary fix due to an issue with higher versions of `marshmallow` interacting with `paramtools`.

cc: @jdebacker 