### PR TITLE
Issue 102 gate external calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Once the package is installed, one can adjust parameters in the OG-Core `Specifi
 from ogcore.parameters import Specifications
 from ogzaf.calibrate import Calibration
 p = Specifications()
-c = Calibration(p)
+c = Calibration(p, update_from_api=True)
 updated_params = c.get_dict()
-p.update_specifications({'initial_debt_ratio': updated_params['initial_debt_ratio']})
+p.update_specifications(updated_params)
 ```
 
 ## Disclaimer

--- a/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_zaf_multiple_industry_energy_tax.py
+++ b/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_zaf_multiple_industry_energy_tax.py
@@ -54,7 +54,7 @@ def main():
     # Update parameters from calibrate.py Calibration class for multiple industries
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_zaf_multiple_industry_govt_borrow_shock.py
+++ b/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_zaf_multiple_industry_govt_borrow_shock.py
@@ -57,7 +57,7 @@ def main():
     # Update parameters from calibrate.py Calibration class
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_zaf_multiple_industry_overall_z_shock.py
+++ b/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_zaf_multiple_industry_overall_z_shock.py
@@ -57,7 +57,7 @@ def main():
     # Update parameters from calibrate.py Calibration class
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/examples/UN_examples/run_og_zaf_multiple_industry_cit_cut.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_cit_cut.py
@@ -57,7 +57,7 @@ def main():
     # Update parameters from calibrate.py Calibration class
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/examples/UN_examples/run_og_zaf_multiple_industry_govt_borrow_shock.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_govt_borrow_shock.py
@@ -61,7 +61,7 @@ def main():
     # Update parameters from calibrate.py Calibration class
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/examples/UN_examples/run_og_zaf_multiple_industry_overall_z_shock.py
+++ b/examples/UN_examples/run_og_zaf_multiple_industry_overall_z_shock.py
@@ -61,7 +61,7 @@ def main():
     # Update parameters from calibrate.py Calibration class
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/examples/run_og_zaf_multiple_industry_cit_cut.py
+++ b/examples/run_og_zaf_multiple_industry_cit_cut.py
@@ -52,7 +52,7 @@ def main():
     # Update parameters from calibrate.py Calibration class for multiple industries
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/examples/run_og_zaf_multiple_industry_energy_tax.py
+++ b/examples/run_og_zaf_multiple_industry_energy_tax.py
@@ -57,7 +57,7 @@ def main():
     # Update parameters from calibrate.py Calibration class for multiple industries
     p.M = 4
     p.I = 5
-    c = Calibration(p)
+    c = Calibration(p, update_from_api=True)
     updated_params = c.get_dict()
     p.update_specifications(updated_params)
     updated_params_tax = {

--- a/ogzaf/calibrate.py
+++ b/ogzaf/calibrate.py
@@ -1,9 +1,9 @@
 from ogzaf import macro_params, income
 from ogzaf import input_output as io
 import os
+import warnings
 import numpy as np
 import datetime
-from ogcore import demographics
 
 
 class Calibration:
@@ -37,72 +37,104 @@ class Calibration:
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
 
+        # Initialize attributes — populated only when update succeeds
+        self.macro_params = {}
+        self.demographic_params = {}
+        self.e = None
+        self.alpha_c = np.array([1.0]) if p.I == 1 else None
+        self.io_matrix = np.array([[1.0]]) if p.M == 1 else None
+
+        if not update_from_api:
+            return
+
+        # --- Online path: try each source independently ---
+
         # Macro estimation
-        self.macro_params = macro_params.get_macro_params(
-            macro_data_start_year,
-            macro_data_end_year,
-            update_from_api=update_from_api,
-        )
+        try:
+            self.macro_params = macro_params.get_macro_params(
+                macro_data_start_year,
+                macro_data_end_year,
+                update_from_api=update_from_api,
+            )
+        except Exception as exc:
+            warnings.warn(
+                f"Macro params update failed: {exc}", stacklevel=2
+            )
 
-        # io matrix and alpha_c
-        if p.I > 1:  # no need if just one consumption good
-            alpha_c_dict = io.get_alpha_c()
-            # check that model dimensions are consistent with alpha_c
-            assert p.I == len(list(alpha_c_dict.keys()))
-            self.alpha_c = np.array(list(alpha_c_dict.values()))
-        else:
-            self.alpha_c = np.array([1.0])
-        if p.M > 1:  # no need if just one production good
-            io_df = io.get_io_matrix()
-            # check that model dimensions are consistent with io_matrix
-            assert p.M == len(list(io_df.keys()))
-            self.io_matrix = io_df.values
-        else:
-            self.io_matrix = np.array([[1.0]])
+        # io matrix and alpha_c (multi-sector only)
+        if p.I > 1:
+            try:
+                alpha_c_dict = io.get_alpha_c()
+                assert p.I == len(list(alpha_c_dict.keys()))
+                self.alpha_c = np.array(list(alpha_c_dict.values()))
+            except Exception as exc:
+                warnings.warn(
+                    f"alpha_c update failed: {exc}", stacklevel=2
+                )
+        if p.M > 1:
+            try:
+                io_df = io.get_io_matrix()
+                assert p.M == len(list(io_df.keys()))
+                self.io_matrix = io_df.values
+            except Exception as exc:
+                warnings.warn(
+                    f"io_matrix update failed: {exc}", stacklevel=2
+                )
 
-        # demographics
-        self.demographic_params = demographics.get_pop_objs(
-            p.E,
-            p.S,
-            p.T,
-            0,
-            99,
-            country_id="710",
-            initial_data_year=p.start_year - 1,
-            final_data_year=p.start_year + 1,
-            GraphDiag=False,
-            download_path=demographic_data_path,
-        )
+        # Demographics + income (atomic — e depends on demographic output)
+        try:
+            from ogcore import demographics
 
-        # demographics for 80 period lives (needed for getting e below)
-        demog80 = demographics.get_pop_objs(
-            20,
-            80,
-            p.T,
-            0,
-            99,
-            country_id="710",
-            initial_data_year=p.start_year - 1,
-            final_data_year=p.start_year + 1,
-            GraphDiag=False,
-        )
+            self.demographic_params = demographics.get_pop_objs(
+                p.E,
+                p.S,
+                p.T,
+                0,
+                99,
+                country_id="710",
+                initial_data_year=p.start_year - 1,
+                final_data_year=p.start_year + 1,
+                GraphDiag=False,
+                download_path=demographic_data_path,
+            )
 
-        # earnings profiles
-        self.e = income.get_e_interp(
-            p.S,
-            self.demographic_params["omega_SS"],
-            demog80["omega_SS"],
-            p.lambdas,
-            plot_path=output_path,
-        )
+            # demographics for 80 period lives (needed for getting e below)
+            demog80 = demographics.get_pop_objs(
+                20,
+                80,
+                p.T,
+                0,
+                99,
+                country_id="710",
+                initial_data_year=p.start_year - 1,
+                final_data_year=p.start_year + 1,
+                GraphDiag=False,
+            )
+
+            # earnings profiles
+            self.e = income.get_e_interp(
+                p.S,
+                self.demographic_params["omega_SS"],
+                demog80["omega_SS"],
+                p.lambdas,
+                plot_path=output_path,
+            )
+        except Exception as exc:
+            warnings.warn(
+                f"Demographics/income update failed: {exc}", stacklevel=2
+            )
+            self.demographic_params = {}
+            self.e = None
 
     # method to return all newly calibrated parameters in a dictionary
     def get_dict(self):
-        dict = {}
-        dict.update(self.macro_params)
-        dict["e"] = self.e
-        dict["alpha_c"] = self.alpha_c
-        dict["io_matrix"] = self.io_matrix
-        dict.update(self.demographic_params)
-
-        return dict
+        d = {}
+        d.update(self.macro_params)
+        d.update(self.demographic_params)
+        if self.e is not None:
+            d["e"] = self.e
+        if self.alpha_c is not None:
+            d["alpha_c"] = self.alpha_c
+        if self.io_matrix is not None:
+            d["io_matrix"] = self.io_matrix
+        return d

--- a/ogzaf/calibrate.py
+++ b/ogzaf/calibrate.py
@@ -57,9 +57,7 @@ class Calibration:
                 update_from_api=update_from_api,
             )
         except Exception as exc:
-            warnings.warn(
-                f"Macro params update failed: {exc}", stacklevel=2
-            )
+            warnings.warn(f"Macro params update failed: {exc}", stacklevel=2)
 
         # io matrix and alpha_c (multi-sector only)
         if p.I > 1:
@@ -68,18 +66,14 @@ class Calibration:
                 assert p.I == len(list(alpha_c_dict.keys()))
                 self.alpha_c = np.array(list(alpha_c_dict.values()))
             except Exception as exc:
-                warnings.warn(
-                    f"alpha_c update failed: {exc}", stacklevel=2
-                )
+                warnings.warn(f"alpha_c update failed: {exc}", stacklevel=2)
         if p.M > 1:
             try:
                 io_df = io.get_io_matrix()
                 assert p.M == len(list(io_df.keys()))
                 self.io_matrix = io_df.values
             except Exception as exc:
-                warnings.warn(
-                    f"io_matrix update failed: {exc}", stacklevel=2
-                )
+                warnings.warn(f"io_matrix update failed: {exc}", stacklevel=2)
 
         # Demographics + income (atomic — e depends on demographic output)
         try:

--- a/ogzaf/input_output.py
+++ b/ogzaf/input_output.py
@@ -51,9 +51,7 @@ def get_alpha_c(sam=None, cons_dict=CONS_DICT):
     if sam is None:
         sam = read_SAM()
     if sam is None:
-        raise RuntimeError(
-            "SAM data is unavailable. Cannot compute alpha_c."
-        )
+        raise RuntimeError("SAM data is unavailable. Cannot compute alpha_c.")
     alpha_c = {}
     overall_sum = 0
     for key, value in cons_dict.items():

--- a/ogzaf/input_output.py
+++ b/ogzaf/input_output.py
@@ -50,6 +50,10 @@ def get_alpha_c(sam=None, cons_dict=CONS_DICT):
     """
     if sam is None:
         sam = read_SAM()
+    if sam is None:
+        raise RuntimeError(
+            "SAM data is unavailable. Cannot compute alpha_c."
+        )
     alpha_c = {}
     overall_sum = 0
     for key, value in cons_dict.items():
@@ -81,6 +85,10 @@ def get_io_matrix(sam=None, cons_dict=CONS_DICT, prod_dict=PROD_DICT):
     """
     if sam is None:
         sam = read_SAM()
+    if sam is None:
+        raise RuntimeError(
+            "SAM data is unavailable. Cannot compute io_matrix."
+        )
     # Create initial matrix as dataframe of 0's to fill in
     io_dict = {}
     for key in prod_dict.keys():

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,171 @@
+"""
+Tests of calibrate.py module — offline and partial-failure behavior
+"""
+
+import warnings
+import pytest
+import numpy as np
+from unittest.mock import MagicMock, patch
+from ogzaf.calibrate import Calibration
+
+
+def _make_mock_p(I=1, M=1):
+    """Create a minimal mock Specifications object."""
+    p = MagicMock()
+    p.I = I
+    p.M = M
+    p.E = 20
+    p.S = 80
+    p.T = 160
+    p.start_year = 2025
+    p.lambdas = np.array(
+        [0.25, 0.25, 0.0625, 0.0625, 0.0625, 0.0625, 0.25]
+    )
+    return p
+
+
+class TestOfflineMode:
+    """Tests for update_from_api=False (the default)."""
+
+    def test_single_sector_returns_identity_values(self):
+        """Single-sector offline: get_dict() returns alpha_c=[1.0] and io_matrix=[[1.0]]."""
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "alpha_c" in d
+        assert "io_matrix" in d
+        np.testing.assert_array_equal(d["alpha_c"], np.array([1.0]))
+        np.testing.assert_array_equal(d["io_matrix"], np.array([[1.0]]))
+
+    def test_single_sector_no_demographics(self):
+        """Offline mode should not include demographics or e."""
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "e" not in d
+        assert "omega" not in d
+        assert "omega_SS" not in d
+        assert "g_n_ss" not in d
+
+    def test_single_sector_no_macro(self):
+        """Offline mode should not include macro params."""
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "g_y_annual" not in d
+        assert "initial_debt_ratio" not in d
+
+    def test_multi_sector_omits_alpha_c_and_io_matrix(self):
+        """Multi-sector offline: alpha_c and io_matrix are None, omitted from get_dict()."""
+        p = _make_mock_p(I=5, M=4)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "alpha_c" not in d
+        assert "io_matrix" not in d
+        assert c.alpha_c is None
+        assert c.io_matrix is None
+
+    def test_get_dict_returns_empty_for_multi_sector(self):
+        """Multi-sector offline: get_dict() returns completely empty dict."""
+        p = _make_mock_p(I=5, M=4)
+        c = Calibration(p, update_from_api=False)
+
+        assert c.get_dict() == {}
+
+    @patch("ogzaf.calibrate.macro_params")
+    @patch("ogzaf.calibrate.io")
+    def test_no_external_calls(self, mock_io, mock_macro):
+        """Offline mode should not call any external-facing functions."""
+        p = _make_mock_p(I=5, M=4)
+        Calibration(p, update_from_api=False)
+
+        mock_macro.get_macro_params.assert_not_called()
+        mock_io.get_alpha_c.assert_not_called()
+        mock_io.get_io_matrix.assert_not_called()
+
+
+class TestOnlinePartialFailure:
+    """Tests for update_from_api=True with mocked partial failures."""
+
+    @patch("ogzaf.calibrate.macro_params")
+    def test_macro_failure_warns_and_omits(self, mock_macro):
+        """When macro update fails, warn and omit from get_dict()."""
+        mock_macro.get_macro_params.side_effect = RuntimeError("API down")
+
+        p = _make_mock_p(I=1, M=1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # Patch demographics to avoid actual API call
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("skip")
+                c = Calibration(p, update_from_api=True)
+
+        # Macro warning should have been emitted
+        macro_warnings = [
+            x for x in w if "Macro params" in str(x.message)
+        ]
+        assert len(macro_warnings) == 1
+
+        d = c.get_dict()
+        assert "g_y_annual" not in d
+        assert "initial_debt_ratio" not in d
+
+    @patch("ogzaf.calibrate.io")
+    @patch("ogzaf.calibrate.macro_params")
+    def test_sam_failure_warns_and_omits(self, mock_macro, mock_io):
+        """When SAM fetch fails, alpha_c and io_matrix are omitted."""
+        mock_macro.get_macro_params.return_value = {"g_y_annual": 0.01}
+        mock_io.get_alpha_c.side_effect = RuntimeError("SAM unavailable")
+        mock_io.get_io_matrix.side_effect = RuntimeError("SAM unavailable")
+
+        p = _make_mock_p(I=5, M=4)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("skip")
+                c = Calibration(p, update_from_api=True)
+
+        alpha_warnings = [
+            x for x in w if "alpha_c" in str(x.message)
+        ]
+        io_warnings = [
+            x for x in w if "io_matrix" in str(x.message)
+        ]
+        assert len(alpha_warnings) == 1
+        assert len(io_warnings) == 1
+
+        d = c.get_dict()
+        assert "alpha_c" not in d
+        assert "io_matrix" not in d
+        # Macro should still be present
+        assert d["g_y_annual"] == 0.01
+
+    @patch("ogzaf.calibrate.macro_params")
+    def test_demographics_failure_warns_and_omits(self, mock_macro):
+        """When demographics fails, e and demographic_params are omitted."""
+        mock_macro.get_macro_params.return_value = {"g_y_annual": 0.01}
+
+        p = _make_mock_p(I=1, M=1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("UN API down")
+                c = Calibration(p, update_from_api=True)
+
+        demo_warnings = [
+            x for x in w if "Demographics" in str(x.message)
+        ]
+        assert len(demo_warnings) == 1
+
+        d = c.get_dict()
+        assert "e" not in d
+        assert "omega" not in d
+        assert "omega_SS" not in d
+        # Macro and single-sector defaults should still be present
+        assert d["g_y_annual"] == 0.01
+        assert "alpha_c" in d
+        assert "io_matrix" in d

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -18,9 +18,7 @@ def _make_mock_p(I=1, M=1):
     p.S = 80
     p.T = 160
     p.start_year = 2025
-    p.lambdas = np.array(
-        [0.25, 0.25, 0.0625, 0.0625, 0.0625, 0.0625, 0.25]
-    )
+    p.lambdas = np.array([0.25, 0.25, 0.0625, 0.0625, 0.0625, 0.0625, 0.25])
     return p
 
 
@@ -105,9 +103,7 @@ class TestOnlinePartialFailure:
                 c = Calibration(p, update_from_api=True)
 
         # Macro warning should have been emitted
-        macro_warnings = [
-            x for x in w if "Macro params" in str(x.message)
-        ]
+        macro_warnings = [x for x in w if "Macro params" in str(x.message)]
         assert len(macro_warnings) == 1
 
         d = c.get_dict()
@@ -129,12 +125,8 @@ class TestOnlinePartialFailure:
                 mock_demog.side_effect = RuntimeError("skip")
                 c = Calibration(p, update_from_api=True)
 
-        alpha_warnings = [
-            x for x in w if "alpha_c" in str(x.message)
-        ]
-        io_warnings = [
-            x for x in w if "io_matrix" in str(x.message)
-        ]
+        alpha_warnings = [x for x in w if "alpha_c" in str(x.message)]
+        io_warnings = [x for x in w if "io_matrix" in str(x.message)]
         assert len(alpha_warnings) == 1
         assert len(io_warnings) == 1
 
@@ -156,9 +148,7 @@ class TestOnlinePartialFailure:
                 mock_demog.side_effect = RuntimeError("UN API down")
                 c = Calibration(p, update_from_api=True)
 
-        demo_warnings = [
-            x for x in w if "Demographics" in str(x.message)
-        ]
+        demo_warnings = [x for x in w if "Demographics" in str(x.message)]
         assert len(demo_warnings) == 1
 
         d = c.get_dict()

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -4,6 +4,7 @@ Tests of input_output.py module
 
 import pandas as pd
 import pytest
+from unittest.mock import patch
 from ogzaf import input_output as io
 
 sam_dict = {
@@ -47,7 +48,7 @@ def test_get_alpha_c(sam_df, cons_dict):
     test_dict = io.get_alpha_c(sam=sam_df, cons_dict=cons_dict)
 
     assert isinstance(test_dict, dict)
-    assert list(test_dict.keys()).sort() == ["Food", "Non-food"].sort()
+    assert sorted(test_dict.keys()) == sorted(["Food", "Non-food"])
     assert test_dict["Food"] == 270 / 900
     assert test_dict["Non-food"] == 630 / 900
 
@@ -68,7 +69,21 @@ def test_get_io_matrix(sam_df, cons_dict, prod_dict):
     )
 
     assert isinstance(test_df, pd.DataFrame)
-    assert list(test_df.columns).sort() == ["Primary", "Secondary"].sort()
-    assert list(test_df.index).sort() == ["Food", "Non-food"].sort()
+    assert sorted(test_df.columns) == sorted(["Primary", "Secondary"])
+    assert sorted(test_df.index) == sorted(["Food", "Non-food"])
     assert test_df.loc["Food", "Primary"] == 2 / 3
     assert test_df.loc["Food", "Secondary"] == 1 / 3
+
+
+@patch("ogzaf.input_output.read_SAM", return_value=None)
+def test_get_alpha_c_raises_on_none_sam(mock_read_sam):
+    """get_alpha_c() raises RuntimeError when SAM data is unavailable."""
+    with pytest.raises(RuntimeError, match="Cannot compute alpha_c"):
+        io.get_alpha_c()
+
+
+@patch("ogzaf.input_output.read_SAM", return_value=None)
+def test_get_io_matrix_raises_on_none_sam(mock_read_sam):
+    """get_io_matrix() raises RuntimeError when SAM data is unavailable."""
+    with pytest.raises(RuntimeError, match="Cannot compute io_matrix"):
+        io.get_io_matrix()


### PR DESCRIPTION
Closes #102

`Calibration.__init__` was calling external APIs — UN demographics, GitHub SAM — even when `update_from_api=False`. That flag was supposed to mean "don't go to the internet" but it wasn't actually doing that. The packaged JSON defaults already have all the values needed for a baseline run, so those calls were unnecessary.

The fix: `Calibration` now treats whatever is already on `p` as the starting point. `get_dict()` only returns values that were actually updated. If something wasn't updated, it's not in the dict — the caller's `p` stays as-is.

- `update_from_api=False` → exits immediately, no external calls, `get_dict()` returns `{}`
- `update_from_api=True` → tries each source separately (macro, SAM, demographics+income). If one fails it warns and skips that source instead of crashing everything.

For the single-sector case, `alpha_c=[1.0]` and `io_matrix=[[1.0]]` were already hardcoded in the original — those are mathematical identities, not fetched data. We kept that behavior and just made it explicit that it applies regardless of `update_from_api`.

`get_alpha_c()` and `get_io_matrix()` now raise `RuntimeError` when SAM data is unavailable, so failures are catchable instead of silently blowing up downstream.

New tests cover offline mode and partial failure. The multisector example scripts are updated to pass `update_from_api=True` since they need live SAM data and should be explicit about it.

The `update_calibration.py` maintenance script discussed in #102 is out of scope here and will be a separate issue/PR.

cc: @jdebacker @gubenda
